### PR TITLE
stopped using tags field and used tagsStructures

### DIFF
--- a/src/Controller/AdvisorController.php
+++ b/src/Controller/AdvisorController.php
@@ -104,6 +104,14 @@ class AdvisorController extends AbstractController
                 }
             }
 
+            if ($form['tagsStructures']->getData()) {
+                $total = count($form['tagsStructures']->getData());
+                for ($i = 0; $i < $total; $i++) {
+                    $tag = $form['tagsStructures']->getData()[$i];
+                    $advisor->addTag($tag);
+                }
+            }
+
             $email = (new TemplatedEmail())
                 ->from(Address::fromString('MaGouvernance <remimayeux@gmail.com>'))
                 ->to('remimayeux@gmail.com')

--- a/src/Form/AdvisorType.php
+++ b/src/Form/AdvisorType.php
@@ -64,7 +64,7 @@ class AdvisorType extends AbstractType
                 ],
                 'required'   => false,
                 ])
-            ->add('tags', EntityType::class, [
+            ->add('tagsStructures', EntityType::class, [
                     'attr' => ['class' => 'selectpicker'],
                     'class' => Tag::class,
                     'query_builder' => function (EntityRepository $er) {

--- a/templates/emails/mailAdmin.html.twig
+++ b/templates/emails/mailAdmin.html.twig
@@ -42,7 +42,7 @@
 
     <tr>
         <td>Dans quel type de structure exercez-vous ou avez-vous exercé un mandat ou plusieurs mandats ? </td>
-        <td>{% if form.data.tags is defined %}{% for tags in form.data.tags %}{{ tags.name}} <br>{% endfor %} {% endif %}</td>
+        <td>{% if form.data.tagsStructures is defined %}{% for tags in form.data.tagsStructures %}{{ tags.name}} <br>{% endfor %} {% endif %}</td>
     </tr>
 
     <tr>

--- a/templates/formAdvisor/formAdvisor.html.twig
+++ b/templates/formAdvisor/formAdvisor.html.twig
@@ -107,7 +107,7 @@
             </div>
             <div class="hideIt1 hideIt2 question">
                 <div class="labels">Dans quel type de structure exercez-vous ou avez-vous exercé un mandat ou plusieurs mandats ? *</div>
-                {{ form_widget(form.tags) }}
+                {{ form_widget(form.tagsStructures) }}
                 <div class="nextOne choices" >Continuer</div>
                 <div class="lastQuestion">
                     <img src="https://image.flaticon.com/icons/png/512/120/120892.png" class="backArrow">


### PR DESCRIPTION
I completely stopped using "tags" as a field in the forms, "tagsStructures" is now being used instead which makes it easier to work with and debugged some weird interactions.